### PR TITLE
Adds Deselect option and prevents copy/paste keystroke hijacking

### DIFF
--- a/js/custom-cell-select.js
+++ b/js/custom-cell-select.js
@@ -193,18 +193,21 @@ angular.module('ui.grid')
                     }
 
                     function documentKeyUp(evt) {
-                        var cKey = 67, vKey = 86;
+                        // if keys are pressed outside of ui-grid contents, ~let it go~
+                        if (angular.element(evt.target).hasClass('ui-grid-cell-contents')) {
+                            var cKey = 67, vKey = 86;
 
-                        // When ctrl+C or cmd+C
-                        if (evt.keyCode === cKey && (evt.ctrlKey || evt.metaKey) && window.getSelection() + '' === '') {
-                            _scope.ugCustomSelect.hiddenInput.val(' ').focus().select();
-                            document.execCommand('copy');
-                            evt.preventDefault();
-                        }
+                            // When ctrl+C or cmd+C
+                            if (evt.keyCode === cKey && (evt.ctrlKey || evt.metaKey) && window.getSelection() + '' === '') {
+                                _scope.ugCustomSelect.hiddenInput.val(' ').focus().select();
+                                document.execCommand('copy');
+                                evt.preventDefault();
+                            }
 
-                        // When ctrl+V or cmd+V
-                        if (evt.keyCode === vKey && (evt.ctrlKey || evt.metaKey) && window.getSelection() + '' === '') {
-                            _scope.ugCustomSelect.hiddenInput.val('').focus();
+                            // When ctrl+V or cmd+V
+                            if (evt.keyCode === vKey && (evt.ctrlKey || evt.metaKey) && window.getSelection() + '' === '') {
+                                _scope.ugCustomSelect.hiddenInput.val('').focus();
+                            }
                         }
                     }
 

--- a/js/custom-cell-select.js
+++ b/js/custom-cell-select.js
@@ -67,6 +67,7 @@ angular.module('ui.grid')
      * @type {SelectionOptions}
      */
     var defaultOptions = {
+        deselectOnOuterClick: true,
         ignoreRightClick: false,
         onRegisterApi: null
     };
@@ -185,6 +186,9 @@ angular.module('ui.grid')
                         if (_scope.ugCustomSelect.isDragging) {
                             _scope.ugCustomSelect.isDragging = false;
                             setSelectedStates();
+                        }
+                        else if ( selectionOptions.deselectOnOuterClick ){
+                          clearDragData();
                         }
                     }
 


### PR DESCRIPTION
We wanted a way for users to deselect from the ui-grid without directly clicking on it, so an if check was added to the bodyMouseUp listener. If the flag is set, clicking outside of the grid will deselect all selected cells using the clearDragData function.

There's was also a bug that prevents copy and pasting into input fields on the entire page because custom-cell-select was consuming all ctrl+c and ctrl+p key events. Now it will only trigger if the event came from the ui-grid-contents!

I really appreciate your addition of the options! I hope this helps anyone else using this ui-grid feature! :)